### PR TITLE
Update _table.scss so sort-icon spans don't change width

### DIFF
--- a/projects/components/src/styles/design/_table.scss
+++ b/projects/components/src/styles/design/_table.scss
@@ -66,28 +66,25 @@
     @apply bg-gray-100 hover:bg-gray-200;
 }
 
-.sort-ascending .sort-icon {
+.sort-icon {
     width: 10px;
     display: inline-flex;
     margin-bottom: -7px;
     margin-left: 10px;
     height: 23px;
-    mask-image: url('/assets/icons/arrow-long-up-mini.svg'); // TODO
-    mask-repeat: no-repeat;
-    mask-size: 1.2rem;
-    mask-position: center;
     @apply bg-gray-500;
 }
 
+.sort-ascending .sort-icon {    
+    mask-image: url('/assets/icons/arrow-long-up-mini.svg'); // TODO
+    mask-repeat: no-repeat;
+    mask-size: 1.2rem;
+    mask-position: center;    
+}
+
 .sort-descending .sort-icon {
-    width: 10px;
-    display: inline-flex;
-    margin-bottom: -7px;
-    margin-left: 10px;
-    height: 23px;
     mask-image: url('/assets/icons/arrow-long-down-mini.svg');
     mask-repeat: no-repeat;
     mask-size: 1.2rem;
     mask-position: center;
-    @apply bg-gray-500;
 }


### PR DESCRIPTION
The `mzSortKey` directive adds spans classed as `sort-icon` to table column headers, for up/down arrows to indicate sorting.

These spans change the width of the column headers if the `.sort-ascending` and `.sort-descending` selectors apply, causing the table to resize whenever a different sort column is changed.

This should keep sortable headers the same size even when the sort arrows are not rendered in them.